### PR TITLE
Fix: Webview CSP compatibility with latest VSCode

### DIFF
--- a/webui/mindmap.html
+++ b/webui/mindmap.html
@@ -3,6 +3,7 @@
 
 <head>
     <meta charset="utf-8" />
+    ${csp}
     <title>mindmap</title>
     <!-- bower:css -->
     <link rel="stylesheet" href="${vscode}/bower_components/bootstrap/dist/css/bootstrap.css" />


### PR DESCRIPTION
This commit fixes the blank/black screen issue when opening .km files in recent versions of VSCode.

Changes:
- Add dynamic CSP meta tag generation using webview.cspSource
- Configure localResourceRoots to allow webui directory access
- Replace hardcoded CSP with placeholder in HTML template

The previous implementation used a static ${vscode} placeholder in the CSP meta tag, which was replaced with an invalid URL format that VSCode couldn't recognize. This caused all resources (CSS, JS, fonts) to be blocked by CSP, resulting in a blank screen.

The fix generates the CSP dynamically in TypeScript using the official webview.cspSource API, which provides the correct format for the current VSCode version.

Fixes rendering issues in VSCode 1.67.0+